### PR TITLE
No need to override GetSSHKeyPath

### DIFF
--- a/xenserver/xenserver.go
+++ b/xenserver/xenserver.go
@@ -142,10 +142,6 @@ func (d *Driver) GetSSHHostname() (string, error) {
 	return d.GetIP()
 }
 
-func (d *Driver) GetSSHKeyPath() string {
-	return filepath.Join(d.StorePath, "id_rsa")
-}
-
 func (d *Driver) GetSSHPort() (int, error) {
 	if d.SSHPort == 0 {
 		d.SSHPort = 22
@@ -732,7 +728,7 @@ func (d *Driver) setMachineNameIfNotSet() {
 }
 
 func (d *Driver) sshKeyPath() string {
-	return filepath.Join(d.StorePath, "id_rsa")
+	return d.GetSSHKeyPath()
 }
 
 func (d *Driver) publicSSHKeyPath() string {


### PR DESCRIPTION
There is no need to override GetSSHKeyPath from the base driver, and it makes this driver incompatible with Rancher 2.0, for instance. The default path for id_rsa is the StorePath for the machine, as seen in the base driver and others.