### PR TITLE
Set IPAddress parameter, fixing Rancher 2.0 issue

### DIFF
--- a/xenserver/xenserver.go
+++ b/xenserver/xenserver.go
@@ -586,6 +586,7 @@ func (d *Driver) wait(timeout time.Duration) (err error) {
 		}
 
 		addr := fmt.Sprintf("%s:%d", ip, port)
+		d.IPAddress = ip
 		log.Infof("Got VM address(%v), Now waiting for SSH", addr)
 		out <- drivers.WaitForSSH(d)
 	}(ctx, out)


### PR DESCRIPTION
When the VM is created and its IP Address is collected, the XenServer machine driver was not setting the IPAddress parameter, expected by Rancher 2.0. This parameter comes from the base machine driver, so it should be set.